### PR TITLE
`predict` has `min_score` parameter to see what score deems anomaly

### DIFF
--- a/rad/rad.py
+++ b/rad/rad.py
@@ -11,8 +11,6 @@ Much of the algorithms in this module are from the works of Liu et al.
 import os
 import s3fs
 import pickle
-import urllib3
-import requests
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -21,10 +19,9 @@ from io import StringIO
 from pyarrow import parquet
 from scipy.stats import ks_2samp
 from collections import namedtuple
-from requests.auth import HTTPBasicAuth
 
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 
 # for modeling IsolationForest node instances
@@ -108,30 +105,6 @@ def fetch_s3(bucket, profile_name=None, folder=None, date=None,
     return frame
 
 
-def fetch_inventory_data(email, password, url=None):
-    """
-    Trivial function to fetch some Host Inventory Data.
-
-    Args:
-        email (str): user authentication key.
-        password (str): password; defaults to `redhat`
-        url (str): endpoint for the host inventory data.
-
-    Returns:
-        dict following retrieval from the Host Inventory API.
-
-    Examples:
-        >>> dic = fetch_inventory_data()
-    """
-    if url is None:
-        url = "https://ci.cloud.paas.upshift.redhat.com/api/inventory/v1/hosts"
-
-    # it is presumed certificates are not needed to access the URL
-    urllib3.disable_warnings()
-    resp = requests.get(url, auth=HTTPBasicAuth(email, password), verify=False)
-    return resp.json()
-
-
 def inventory_data_to_pandas(dic):
     """
     Parse a JSON object, fetched from the Host Inventory Service, and massage
@@ -145,10 +118,6 @@ def inventory_data_to_pandas(dic):
 
     Returns:
         DataFrame: each column is a feature and its cell is its value.
-
-    Examples:
-        >>> dic = fetch_inventory_data()  # provide your specific credentials
-        >>> frame = inventory_data_to_pandas(dic)
     """
 
     # do some exception handling to make sure the right data is passed-in

--- a/rad/rad.py
+++ b/rad/rad.py
@@ -12,26 +12,19 @@ import os
 import s3fs
 import pickle
 import urllib3
-import logging
 import requests
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
 
+from io import StringIO
 from pyarrow import parquet
 from scipy.stats import ks_2samp
 from collections import namedtuple
 from requests.auth import HTTPBasicAuth
 
 
-# for plotting purposes only
-try:
-    import matplotlib.pyplot as plt
-    from io import StringIO
-except ImportError:
-    logging.warn("matplotlib not available; plotting not possible.")
-
-
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 
 # for modeling IsolationForest node instances
@@ -444,7 +437,7 @@ class IsolationForest:
             raise ValueError("Argument must model an IsolationForest")
         return forest
 
-    def predict(self, array):
+    def predict(self, array, min_score=0.5):
         """
         Given a new user-provided array, generate an anomaly score. Such scores
         range from 0 to 1; values near 0 are not anomalous, while values near
@@ -452,6 +445,7 @@ class IsolationForest:
 
         Args:
             array (ndarray): numeric array comprised of N records.
+            min_score (float): minimum-allowable score to be labeled an anomaly.
 
         Returns:
             out: array that contains the `id`, `score`, and `depth` per record.
@@ -482,7 +476,7 @@ class IsolationForest:
             # each record (row) has a score and depth
             record = {"score": score,
                       "depth": depth_scaled,
-                      "is_anomalous": bool(score > .5)}
+                      "is_anomalous": bool(score > min_score)}
 
             # if the index is a MultiIndex each index name index value
             if isinstance(ix, (tuple, list)):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="rad",
-    version="0.9.1",
+    version="0.9.2",
     description="AI-Ops Red Hat Anomaly Detection (RAD)",
     author="Parsa Hosseini, Ph.D.",
     author_email="phossein@redhat.com",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="rad",
-    version="0.9.2",
+    version="0.9.3",
     description="AI-Ops Red Hat Anomaly Detection (RAD)",
     author="Parsa Hosseini, Ph.D.",
     author_email="phossein@redhat.com",

--- a/tests/test_rad.py
+++ b/tests/test_rad.py
@@ -197,6 +197,24 @@ class TestIsolationForest(unittest.TestCase):
         baseline = set(self.forest.X.columns)
         self.assertTrue(len(columns.intersection(baseline)) >= 0)
 
+    def test_real_positive_anomaly_is_predicted(self):
+        """
+        Test that really-large values are labeled as anomalies
+        """
+        data = np.repeat(np.finfo(float).max, self.size[1])
+        data = np.reshape(data, (1, self.size[1]))
+        anom = list(map(lambda x: x["is_anomalous"], self.forest.predict(data)))
+        self.assertTrue(all(anom))
+
+    def test_real_negative_anomaly_is_predicted(self):
+        """
+        Test that really-large values are labeled as anomalies
+        """
+        data = np.repeat(np.finfo(float).min, self.size[1])
+        data = np.reshape(data, (1, self.size[1]))
+        anom = list(map(lambda x: x["is_anomalous"], self.forest.predict(data)))
+        self.assertTrue(all(anom))
+
 
 class TestIsolationTree(unittest.TestCase):
 


### PR DESCRIPTION
* `min_score` help determine a minimum-allowable anomaly score; was hard-coded to 0.5 before.
* new use-cases to show truly-anomalous records are indeed anomalous.